### PR TITLE
Provide "handles" to the graph objects for use by extensions

### DIFF
--- a/history_viewer.tcl
+++ b/history_viewer.tcl
@@ -157,6 +157,7 @@ add_background "history"
 add_de1_variable "history" 680 60 -width [rescale_x_skin 900]  -text "" -font $::font_big -fill [theme primary_light] -anchor "nw" -justify "center" -state "hidden" -textvariable {[past_title]}
 
 add_de1_widget "history" graph 680 240 {
+	set ::skin::mimojacafe::graph::history $widget
 	#Target
 	$widget element create line_history_espresso_pressure_goal -xdata history_elapsed -ydata history_pressure_goal -symbol none -label "" -linewidth [rescale_x_skin 8] -color [theme primary_light]  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes {5 5};
 	$widget element create line_history_espresso_flow_goal -xdata history_elapsed -ydata history_flow_goal -symbol none -label "" -linewidth [rescale_x_skin 8] -color [theme secondary_light] -smooth $::settings(live_graph_smoothing_technique) -pixels 0  -dashes {5 5};

--- a/interfaces/default_ui.tcl
+++ b/interfaces/default_ui.tcl
@@ -217,6 +217,8 @@ if {$::iconik_settings(show_steam) == 1} {
 
 add_de1_widget "off" graph 580 230 {
 
+	set ::skin::mimojacafe::graph::espresso $widget
+
 	$widget element create line_espresso_pressure_goal -xdata espresso_elapsed -ydata espresso_pressure_goal -symbol none -label "" -linewidth [rescale_x_skin 8] -color [theme primary_light]  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes {5 5};
 	$widget element create line2_espresso_pressure -xdata espresso_elapsed -ydata espresso_pressure -symbol none -label "" -linewidth [rescale_x_skin 12] -color [theme primary]  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes $::settings(chart_dashes_pressure);
 
@@ -270,6 +272,9 @@ add_de1_widget "off" graph 580 230 {
 
 if {$::iconik_settings(show_steam) == 1} {
 	add_de1_widget "off" graph 580 830 {
+
+		set ::skin::mimojacafe::graph::steam $widget
+
 		$widget element create line_steam_pressure -xdata steam_elapsed -ydata steam_pressure -symbol none -label "" -linewidth [rescale_x_skin 6] -color #86C240  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes $::settings(chart_dashes_pressure);
 		$widget element create line_steam_flow -xdata steam_elapsed -ydata steam_flow -symbol none -label "" -linewidth [rescale_x_skin 6] -color #43B1E3  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes $::settings(chart_dashes_flow);
 		$widget element create line_steam_temperature -xdata steam_elapsed -ydata steam_temperature -symbol none -label "" -linewidth [rescale_x_skin 6] -color #FF2600 -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes $::settings(chart_dashes_temperature);

--- a/interfaces/magadan_ui.tcl
+++ b/interfaces/magadan_ui.tcl
@@ -217,6 +217,8 @@ if {$::iconik_settings(show_steam) == 1} {
 
 add_de1_widget "off" graph 510 280 {
 
+	set ::skin::mimojacafe::graph::espresso $widget
+
 	$widget element create line_espresso_pressure_goal -xdata espresso_elapsed -ydata espresso_pressure_goal -symbol none -label "" -linewidth [rescale_x_skin 8] -color [theme primary_light]  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes {5 5};
 	$widget element create line2_espresso_pressure -xdata espresso_elapsed -ydata espresso_pressure -symbol none -label "" -linewidth [rescale_x_skin 12] -color [theme primary]  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes $::settings(chart_dashes_pressure);
 
@@ -270,6 +272,9 @@ add_de1_widget "off" graph 510 280 {
 
 if {$::iconik_settings(show_steam) == 1} {
 	add_de1_widget "off" graph 580 830 {
+
+		set ::skin::mimojacafe::graph::steam $widget
+
 		$widget element create line_steam_pressure -xdata steam_elapsed -ydata steam_pressure -symbol none -label "" -linewidth [rescale_x_skin 6] -color #86C240  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes $::settings(chart_dashes_pressure);
 		$widget element create line_steam_flow -xdata steam_elapsed -ydata steam_flow -symbol none -label "" -linewidth [rescale_x_skin 6] -color #43B1E3  -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes $::settings(chart_dashes_flow);
 		$widget element create line_steam_temperature -xdata steam_elapsed -ydata steam_temperature -symbol none -label "" -linewidth [rescale_x_skin 6] -color #FF2600 -smooth $::settings(live_graph_smoothing_technique) -pixels 0 -dashes $::settings(chart_dashes_temperature);

--- a/skin.tcl
+++ b/skin.tcl
@@ -6,6 +6,7 @@ set ::skindebug 0
 set ::debugging 0
 set ::history_to_restore_after_cleanup {}
 
+namespace eval ::skin::mimojacafe::graph {}
 
 source "[skin_directory]/settings.tcl"
 


### PR DESCRIPTION
I'm far from picky with names here. sed away...

Provide access to the graph objects after skin load

  ::skin::mimojacafe::graph::espresso
  ::skin::mimojacafe::graph::steam
  ::skin::mimojacafe::graph::hitory

Signed-Off-By: Jeff Kletsky <git-commits@allycomm.com>