### PR TITLE
Update DUI theme

### DIFF
--- a/theme.tcl
+++ b/theme.tcl
@@ -139,11 +139,12 @@ proc init_MimojaCafe_dui_theme {} {
 		dcheckbox.font_family "Font Awesome 5 Pro"
 		dcheckbox.font_size 18
 		dcheckbox.fill [::theme background_text]
+		dcheckbox.disabledfill $disabled_colour
 		dcheckbox.anchor nw
 		dcheckbox.justify left
 		
-		dcheckbox_label.pos "en 30 -10"
-		dcheckbox_label.anchor nw
+		dcheckbox_label.pos "e 30 0"
+		dcheckbox_label.anchor w
 		dcheckbox_label.justify left
 		
 		listbox.relief sunken
@@ -266,24 +267,36 @@ proc init_MimojaCafe_dui_theme {} {
 		dbutton.shape.menu_dlg_btn rect
 		dbutton.fill.menu_dlg_btn {}
 		dbutton.disabledfill.menu_dlg_btn {}
-		dbutton_label.pos.menu_dlg_btn {0.3 0.4} 
+		dbutton_label.pos.menu_dlg_btn {0.25 0.4} 
 		dbutton_label.anchor.menu_dlg_btn w
 		dbutton_label.fill.menu_dlg_btn [::theme button_text_light]
 		dbutton_label.disabledfill.menu_dlg_btn $disabled_colour
 		
-		dbutton_label1.pos.menu_dlg_btn {0.3 0.78} 
+		dbutton_label1.pos.menu_dlg_btn {0.25 0.78} 
 		dbutton_label1.anchor.menu_dlg_btn w
 		dbutton_label1.fill.menu_dlg_btn #bbb
 		dbutton_label1.disabledfill.menu_dlg_btn $disabled_colour
 		dbutton_label1.font_size.menu_dlg_btn -3
 		
-		dbutton_symbol.pos.menu_dlg_btn {0.18 0.5} 
+		dbutton_symbol.pos.menu_dlg_btn {0.15 0.5} 
 		dbutton_symbol.anchor.menu_dlg_btn center
 		dbutton_symbol.fill.menu_dlg_btn [::theme button_text_light]
 		dbutton_symbol.disabledfill.menu_dlg_btn $disabled_colour
 		
 		line.fill.menu_dlg_sepline #ddd
-		line.width.menu_dlg_sepline 1 
+		line.width.menu_dlg_sepline 1
+		
+		dtext.fill.menu_dlg [::theme button_text_light]
+		dtext.disabledfill.menu_dlg $disabled_colour
+		dcheckbox.fill.menu_dlg [::theme button_text_light]
+		dcheckbox.disabledfill.menu_dlg $disabled_colour
+		dcheckbox_label.fill.menu_dlg [::theme button_text_light]
+		dcheckbox_label.disabledfill.menu_dlg $disabled_colour
+		
+		dbutton.shape.menu_dlg round
+		dbutton.radius.menu_dlg 25
+		dbutton.fill.menu_dlg [::theme button_tertiary]
+		dbutton_label.font_family.menu_dlg "Mazzard Regular"
 	}]
 	
 	


### PR DESCRIPTION
- New `menu_dlg` styles, used to properly format the new DYE menu dialogs under MimojaCafe.
- Improve dcheckbox widgets alignment of symbol and label.