### PR TITLE
Change how DYE is open

### DIFF
--- a/skin.tcl
+++ b/skin.tcl
@@ -174,7 +174,7 @@ proc iconik_get_status_text {} {
 }
 
 proc show_DYE_page {} {
-    dui page load DYE current -theme MimojaCafe
+	plugins::DYE::open -which_shot default -theme MimojaCafe -coords {700 250} -anchor nw
 }
 
 proc iconik_status_tap {} {


### PR DESCRIPTION
This changes how DYE is open when the "Describe" button is tapped, so as to apply the new DYE setting that defines the default action to launch DYE.

For example, if "Launch dialog" is selected in the DYE settings:
![image](https://user-images.githubusercontent.com/60866/140910876-8b2bb48d-a1a4-4e8c-a676-89e932ae26a9.png)

This will appear when the "Describe" button is tapped:
![image](https://user-images.githubusercontent.com/60866/140911035-1f2d64d5-bba3-46c6-b6e3-39bf356d91b9.png)



