### PR TITLE
make DYE optional and only use history viewer if DYE is disabled

### DIFF
--- a/interfaces/default_ui.tcl
+++ b/interfaces/default_ui.tcl
@@ -217,7 +217,7 @@ rectangle "default_off" 0 1410 2560 1600 [::theme background_highlight]
 
 ## Status and MISC buttons
 create_button "default_off" 80 1440 480 1560    $::font_tiny [::theme button_tertiary] [::theme button_text_light] { say [translate "settings"] $::settings(sound_button_in); iconik_status_tap } {[iconik_get_status_text]}
-create_button "default_off" 580 1440 980 1560   $::font_tiny [::theme button_tertiary] [::theme button_text_light] { say [translate "settings"] $::settings(sound_button_in); show_DYE_page} {[translate "Describe"]}
+create_button "default_off" 580 1440 980 1560   $::font_tiny [::theme button_tertiary] [::theme button_text_light] { say [translate "settings"] $::settings(sound_button_in); show_DYE_page} {[iconik_get_describe_text]}
 
 create_button "default_off" 1080 1440 1480 1560 $::font_tiny [::theme button_tertiary] [::theme button_text_light] { say [translate "settings"] $::settings(sound_button_in); iconik_toggle_cleaning } { [translate "Clean"]} 
 create_button "default_off" 1580 1440 1980 1560 $::font_tiny [::theme button_tertiary] [::theme button_text_light] { say [translate "settings"] $::settings(sound_button_in); iconik_open_profile_settings } {[translate "Settings"]}

--- a/skin.tcl
+++ b/skin.tcl
@@ -28,11 +28,10 @@ proc iconik_wakeup {} {
 catch {
 	package require sqlite3
 
-	if { [plugins available DYE] } {
+	if { [plugins enabled DYE] } {
 		if { [plugins available SDB] } {
 			plugins enable SDB
 		}
-		plugins enable DYE
 		dui page load DYE current -theme MimojaCafe
 	}
 }
@@ -195,8 +194,20 @@ proc iconik_get_status_text {} {
 
 }
 
+proc iconik_get_describe_text {} {
+	if { [plugins enabled DYE] } {
+		return [translate "Describe"]
+	} else {
+		return [translate "History"]
+	}
+}
+
 proc show_DYE_page {} {
-	plugins::DYE::open -which_shot default -theme MimojaCafe -coords {700 250} -anchor nw
+	if { [plugins enabled DYE] } {
+		plugins::DYE::open -which_shot default -theme MimojaCafe -coords {700 250} -anchor nw
+	} else {
+		history_viewer open
+	}
 }
 
 proc iconik_status_tap {} {


### PR DESCRIPTION
Hi @Mimoja,

personally I don't use DYE and wonder if it breaks anything if we check if DYE is enabled and directly show the plain history viewer if not. This PR introduces the behavior described and as far as I was able to test doesn't break anything. I would be happy if you accept it.

BR, Silas