### PR TITLE
allow to tare a connected scale by tapping the status widget

### DIFF
--- a/skin.tcl
+++ b/skin.tcl
@@ -160,7 +160,7 @@ proc iconik_get_status_text {} {
 		}
 		0 {
 			if {[::device::scale::is_connected]} {
-				return [translate "Ready\nScale connected"]
+				return [translate "Ready\nTap to tare scale"]
 			}
 
 			return [translate "Ready"]
@@ -206,6 +206,10 @@ proc iconik_status_tap {} {
 
 	if {$::de1_num_state($::de1(state)) == "Espresso"} {
 		start_next_step
+	}
+
+	if {[::device::scale::is_connected]} {
+		::device::scale::tare
 	}
 }
 

--- a/skin.tcl
+++ b/skin.tcl
@@ -206,9 +206,7 @@ proc iconik_status_tap {} {
 
 	if {$::de1_num_state($::de1(state)) == "Espresso"} {
 		start_next_step
-	}
-
-	if {[::device::scale::is_connected]} {
+	} elseif {[::device::scale::is_connected]} {
 		::device::scale::tare
 	}
 }


### PR DESCRIPTION
Hi @Mimoja,

when weighting beans I always missed the possibility to manually tare a connected scale in MimojaCafe. This became even more urgent when recently the tare button of my Decent scale broke. Until I got a replacement device I was really happy to tare the scale using this PR's code. Also with the new scale I prefer a workflow that only needs tablet interaction. Since I could imagine that some other users agree and the change does not break anything, I hope you accept it.

BR, Silas